### PR TITLE
Fix the docs for exporting auth variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ re-creating issues locally.
 ## Setup
 
 ```bash
-export JENKINS_USER="xxx"
+export JENKINS_LOGIN="xxx"
 export JENKINS_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 


### PR DESCRIPTION
The code says `JENKINS_LOGIN`, but the docs mention `JENKINS_USER`.
